### PR TITLE
Fixed compilation error

### DIFF
--- a/Firmware/ESP32/main/openhaystack_main.c
+++ b/Firmware/ESP32/main/openhaystack_main.c
@@ -224,7 +224,7 @@ uint8_t* read_line_or_dismiss(int* len) {
     int size;
     uint8_t *ptr = line;
     while(1) {
-        size = uart_read_bytes(UART_PORT_NUM, (unsigned char *)ptr, 1, 20 / portTICK_RATE_MS);
+        size = uart_read_bytes(UART_PORT_NUM, (unsigned char *)ptr, 1, 20 / portTICK_PERIOD_MS);
         if (size == 1) {
             if (*ptr == '\n') {
                 *ptr = 0;


### PR DESCRIPTION
Fix error during build:
```cpp
 send-my/Firmware/ESP32/main/openhaystack_main.c:227:77: error: 'portTICK_RATE_MS' undeclared (first use in this function); did you mean 'portTICK_PERIOD_MS'?
        227 |         size = uart_read_bytes(UART_PORT_NUM, (unsigned char *)ptr, 1, 20 / portTICK_RATE_MS);
            |                                                                             ^~~~~~~~~~~~~~~~
            |                                                                             portTICK_PERIOD_MS
```